### PR TITLE
FIX: Fixed unclosed codeblock in CSS docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 📏 Coding Guidelines Changelog
 
+## 3.0.1 - 2023-08-30
+
+* CSS - Fixed unclosed codeblock
+
 ## 3.0.0 - 2023-08-23
 
 * Added accessibility section

--- a/css/README.md
+++ b/css/README.md
@@ -1435,6 +1435,7 @@ $LIGHT_GREY: #d4d7d9;
   // Before Canvas 3.0.0
   @include ms(0);
 }
+```
 
 * Use rem, relative ems
 * They're easier to understand as they're always relative to the base font-size


### PR DESCRIPTION
Spotted an unclosed codeblock in the CSS guide-lines page

Fixed by adding in the missing codeblock closing tags